### PR TITLE
Style filters and training cards

### DIFF
--- a/scss/_publicwebsite_styles.scss
+++ b/scss/_publicwebsite_styles.scss
@@ -110,17 +110,28 @@
     .search-category__list {
         max-width: 70%;
         margin: 4rem auto;
+        @media (max-width: $g-bp3) {
+            max-width: 100%;
+        }
         .search-category__list-ul {
             display: flex;
             flex-wrap: wrap;
             flex-direction: row;
             justify-content: center;
+            @media (max-width: $g-bp2) {
+                flex-wrap: nowrap;
+                flex-direction: column;
+                align-items: center;
+            }
         }
         .search-category__item {
             margin: 0 1rem 1rem 0;
             border: 0.1rem solid $color-gray-800;
             width: auto;
             text-align: center;
+            @media (max-width: $g-bp2) {
+                margin: auto auto 1rem auto;
+            }
         }
         .search-category__item-link {
             padding: 0.5rem 1.6rem 0.5rem 1.2rem;

--- a/scss/_publicwebsite_styles.scss
+++ b/scss/_publicwebsite_styles.scss
@@ -172,14 +172,12 @@
 }
 
 .training-list__container {
+    display: flex;
     padding: 2.4rem 0;
     border-bottom: 1px solid $color-gray-100;
     max-width: 100%;
-    display: flex;
-    flex-wrap: wrap;
     .training-list__container-left {
-        width: 75%;
-        min-width: 30rem;
+        width: 90%;
         text-align: left;
         .training-list__title {
             font-size: 2rem;
@@ -199,10 +197,12 @@
         }
     }
     .training-list__container-right {
-        width: 25%;
-        min-width: 20rem;
-        text-align: right;
-        padding-top: 5rem;
+        width: 10%;
+        min-width: 10%;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
     }
 }
 
@@ -294,6 +294,9 @@
     .trainer-card__trainings {
         padding-top: 6rem;
         width: 80%;
+        @media (max-width: $g-bp3){
+            width: 100%;
+        }
         .trainer-card__trainings-label {
             font-size: 1.6rem;
             font-weight: 700;
@@ -318,8 +321,10 @@
             .training-list__container-right {
                 width: 10%;
                 min-width: 10%;
-                vertical-align: top;
-                padding: 0;
+                display: flex;
+                flex-direction: row;
+                justify-content: center;
+                align-items: center;
             }
         }
     }

--- a/templates/components/training-list-demo.html
+++ b/templates/components/training-list-demo.html
@@ -75,4 +75,5 @@
                 <a href="nom-de-la-formation.php" class="training-list__more-link">Détail de la formation <img src="./icons/chevron-right--blue.svg" class="o-svg-icon--small chevron-icon" /></a> </div>
         </div>
     </div>
+</div>
     <!-- EO pour la demo -->

--- a/templates/components/training-list-demo.html
+++ b/templates/components/training-list-demo.html
@@ -15,7 +15,9 @@
         </div>
         <div class="training-list__container-right">
             <div class="training-list__more">
-                <a href="nom-de-la-formation.php" class="training-list__more-link">Détail de la formation <img src="./icons/chevron-right--blue.svg" class="o-svg-icon--small chevron-icon" /></a> </div>
+                <!-- Lien vers la fiche de la formation -->
+                <a href="nom-de-la-formation.php" class="training-list__more-link"><img src="./icons/chevron-right--blue.svg" class="o-svg-icon--large chevron-icon" /></a>
+            </div>
         </div>
     </div>
 </div>
@@ -34,7 +36,9 @@
         </div>
         <div class="training-list__container-right">
             <div class="training-list__more">
-                <a href="nom-de-la-formation.php" class="training-list__more-link">Détail de la formation <img src="./icons/chevron-right--blue.svg" class="o-svg-icon--small chevron-icon" /></a> </div>
+                <!-- Lien vers la fiche de la formation -->
+                <a href="nom-de-la-formation.php" class="training-list__more-link"><img src="./icons/chevron-right--blue.svg" class="o-svg-icon--large chevron-icon" /></a>
+            </div>
         </div>
     </div>
 </div>
@@ -53,7 +57,9 @@
         </div>
         <div class="training-list__container-right">
             <div class="training-list__more">
-                <a href="nom-de-la-formation.php" class="training-list__more-link">Détail de la formation <img src="./icons/chevron-right--blue.svg" class="o-svg-icon--small chevron-icon" /></a> </div>
+                <!-- Lien vers la fiche de la formation -->
+                <a href="nom-de-la-formation.php" class="training-list__more-link"><img src="./icons/chevron-right--blue.svg" class="o-svg-icon--large chevron-icon" /></a>
+            </div>
         </div>
     </div>
 </div>
@@ -72,7 +78,9 @@
         </div>
         <div class="training-list__container-right">
             <div class="training-list__more">
-                <a href="nom-de-la-formation.php" class="training-list__more-link">Détail de la formation <img src="./icons/chevron-right--blue.svg" class="o-svg-icon--small chevron-icon" /></a> </div>
+                <!-- Lien vers la fiche de la formation -->
+                <a href="nom-de-la-formation.php" class="training-list__more-link"><img src="./icons/chevron-right--blue.svg" class="o-svg-icon--large chevron-icon" /></a>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/components/training-list-lecerf-demo.html
+++ b/templates/components/training-list-lecerf-demo.html
@@ -15,3 +15,4 @@
             <a href="nom-de-la-formation.php" class="training-list__more-link"><img src="./icons/chevron-right--blue.svg" class="o-svg-icon--large chevron-icon" /></a>
         </div>
     </div>
+</div>

--- a/templates/components/training-list.html
+++ b/templates/components/training-list.html
@@ -17,7 +17,8 @@
         <div class="training-list__container-right">
             <div class="training-list__more">
                 <!-- Lien vers la fiche de la formation -->
-                <a href="nom-de-la-formation.php" class="training-list__more-link">Détail de la formation <img src="./icons/chevron-right--blue.svg" class="o-svg-icon--small chevron-icon" /></a> </div>
+                <a href="nom-de-la-formation.php" class="training-list__more-link"><img src="./icons/chevron-right--blue.svg" class="o-svg-icon--large chevron-icon" /></a>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Style training filters for smaller screens: 
- 1 filter per row, 
- width fitting filter content, 
- centered

Style training cards for lists:
- on trainer page, use full width on smaller screens
- on trainings page, use large chevron icon only instead of "more details" text together with the smaller icon + make sure it doesn't wrap to another line.

_**Note: I didn't commit the compiled css files. Make sure to compile them and add the compiled files in a commit after you rebase on the up to date main branch and before you merge the branch into main :)**_